### PR TITLE
feat: update ContentQueue properties when actual FPS is read from MP4

### DIFF
--- a/src/helpers/structs.rs
+++ b/src/helpers/structs.rs
@@ -60,6 +60,10 @@ impl ContentQueue {
     pub fn bytes_len(&self) -> usize {
         self.elements.iter().map(|el| el.data.len()).sum()
     }
+
+    pub fn update_el_per_second(&mut self, new_el_per_second: usize) {
+        self.el_per_second = new_el_per_second;
+    }
 }
 
 pub struct ScreenGuard {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,14 @@ fn main() {
     let raw_video_buffer = Arc::new(Mutex::new(ContentQueue::new(frames_per_second)));
     let encoded_video_buffer = Arc::new(Mutex::new(ContentQueue::new(frames_per_second)));
     let audio_buffer = Arc::new(Mutex::new(ContentQueue::new(samples_per_second)));
+    let ready_audio_buffer = Arc::new(Mutex::new(ContentQueue::new(samples_per_second)));
+    let ready_video_buffer = Arc::new(Mutex::new(ContentQueue::new(frames_per_second)));
 
     let mut demux = Demultiplexer::new(
         raw_video_buffer.clone(),
         audio_buffer.clone(),
+        encoded_video_buffer.clone(),
+        ready_video_buffer.clone(),
         demultiplexing_done_tx,
         url,
         frame_interval_ms,
@@ -86,9 +90,6 @@ fn main() {
     thread::spawn(move || {
         encoder.encode().expect("Failed to start encoding");
     });
-
-    let ready_audio_buffer = Arc::new(Mutex::new(ContentQueue::new(samples_per_second)));
-    let ready_video_buffer = Arc::new(Mutex::new(ContentQueue::new(frames_per_second)));
 
     let audio_adapter =
         audio::adapter::AudioAdapter::new(ready_audio_buffer.clone(), audio_queueing_done_rx)


### PR DESCRIPTION
## Summary
- Adds `update_el_per_second()` method to `ContentQueue` to allow dynamic FPS updates
- Updates `Demultiplexer` to accept references to all video content queues
- Updates all video content queues when actual FPS is determined from MP4 metadata (in `demultiplexer.rs:298-301`)
- Moves `ready_video_buffer` creation before `demux` initialization to fix dependency order

## Test plan
- [x] Code compiles successfully with `cargo check`
- [ ] Manual testing with different video sources to verify FPS detection works
- [ ] Verify video playback synchronization with actual FPS instead of hardcoded 30 FPS

🤖 Generated with [Claude Code](https://claude.ai/code)