### PR TITLE
feat: add video scaling for high-resolution displays

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn run_direct_playback(input: &str, use_screen_guard: bool, center_video: bool) 
     });
 
     let mut encoder =
-        Encoder::new(demultiplexer_video_rx, video_encoding_tx, y_offset).expect("Failed to create encoder");
+        Encoder::new(demultiplexer_video_rx, video_encoding_tx, y_offset, None).expect("Failed to create encoder");
 
     let encode_handle = thread::spawn(move || {
         encoder.encode().expect("Failed to start encoding");
@@ -128,7 +128,7 @@ fn run_direct_playback(input: &str, use_screen_guard: bool, center_video: bool) 
     let _ = video_handle.join();
 }
 
-pub fn start_playback_async(input: &str, center_video: bool) -> PlaybackHandle {
+pub fn start_playback_async(input: &str, center_video: bool, video_rows: Option<u16>) -> PlaybackHandle {
     let cancel_flag = Arc::new(AtomicBool::new(false));
 
     let (demultiplexer_audio_tx, demultiplexer_audio_rx) = channel::<RawAudioMessage>();
@@ -147,7 +147,7 @@ pub fn start_playback_async(input: &str, center_video: bool) -> PlaybackHandle {
 
     let cancel = cancel_flag.clone();
     let encode_handle = thread::spawn(move || {
-        let mut encoder = Encoder::new(demultiplexer_video_rx, video_encoding_tx, y_offset)
+        let mut encoder = Encoder::new(demultiplexer_video_rx, video_encoding_tx, y_offset, video_rows)
             .expect("Failed to create encoder");
         encoder.set_cancel_flag(cancel);
         let _ = encoder.encode();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -128,8 +128,8 @@ fn handle_results_mode(app: &mut App, key: KeyCode, playback: &mut Option<Playba
                 app.playing_url = Some(result.url.clone());
                 app.mode = AppMode::Playing;
 
-                // Start playback asynchronously
-                *playback = Some(crate::start_playback_async(&result.url, false, None));
+                // Start playback asynchronously with video area constraints
+                *playback = Some(crate::start_playback_async(&result.url, false, Some(ui::VIDEO_ROWS)));
             }
         }
         _ => {}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -129,7 +129,7 @@ fn handle_results_mode(app: &mut App, key: KeyCode, playback: &mut Option<Playba
                 app.mode = AppMode::Playing;
 
                 // Start playback asynchronously
-                *playback = Some(crate::start_playback_async(&result.url, false));
+                *playback = Some(crate::start_playback_async(&result.url, false, None));
             }
         }
         _ => {}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use crate::tui::app::{App, AppMode};
 use crate::tui::search::SearchResult;
 
-const VIDEO_ROWS: u16 = 25;
+pub const VIDEO_ROWS: u16 = 25;
 
 pub fn render(f: &mut Frame, app: &App) {
     let chunks = Layout::default()

--- a/src/video/encoder.rs
+++ b/src/video/encoder.rs
@@ -16,9 +16,12 @@ pub struct Encoder {
     height: usize,
     term_width: u16,
     term_height: u16,
+    term_cols: u16,
+    term_rows: u16,
     producer_rx: mpsc::Receiver<RawVideoMessage>,
     producer_tx: mpsc::Sender<EncodedVideoMessage>,
     force_y_offset: Option<usize>,
+    video_rows: Option<u16>,
     cancel_flag: Option<Arc<AtomicBool>>,
 }
 
@@ -27,10 +30,12 @@ impl Encoder {
         producer_rx: mpsc::Receiver<RawVideoMessage>,
         producer_tx: mpsc::Sender<EncodedVideoMessage>,
         force_y_offset: Option<usize>,
+        video_rows: Option<u16>,
     ) -> Res<Self> {
-        let (term_width, term_height) = Self::get_terminal_size().unwrap_or((1280, 720));
+        let (term_width, term_height, term_cols, term_rows) =
+            Self::get_terminal_size().unwrap_or((1280, 720, 80, 24));
 
-        if term_width == 0 || term_height == 0 {
+        if term_width == 0 || term_height == 0 || term_cols == 0 || term_rows == 0 {
             return Err("Invalid terminal size".into());
         }
 
@@ -39,15 +44,58 @@ impl Encoder {
             height: 360,
             term_width,
             term_height,
+            term_cols,
+            term_rows,
             producer_rx,
             producer_tx,
             force_y_offset,
+            video_rows,
             cancel_flag: None,
         })
     }
 
     pub fn set_cancel_flag(&mut self, flag: Arc<AtomicBool>) {
         self.cancel_flag = Some(flag);
+    }
+
+    /// Returns pixel dimensions per cell (width, height).
+    fn cell_pixel_dimensions(&self) -> (f64, f64) {
+        (
+            self.term_width as f64 / self.term_cols as f64,
+            self.term_height as f64 / self.term_rows as f64,
+        )
+    }
+
+    /// Calculate display dimensions (columns, rows) for Kitty protocol scaling.
+    /// Maintains aspect ratio while fitting within available space.
+    fn calculate_display_dimensions(&self) -> (u16, u16) {
+        let (cell_width_px, cell_height_px) = self.cell_pixel_dimensions();
+
+        // Determine available rows
+        let available_rows = self.video_rows.unwrap_or(self.term_rows);
+        let available_cols = self.term_cols;
+
+        // Calculate target rows (video height in cells)
+        // Start by filling available height
+        let target_rows = available_rows;
+
+        // Calculate corresponding width to maintain aspect ratio
+        let video_aspect = self.width as f64 / self.height as f64;
+        let target_height_px = target_rows as f64 * cell_height_px;
+        let target_width_px = target_height_px * video_aspect;
+        let mut target_cols = (target_width_px / cell_width_px).round() as u16;
+
+        // Clamp to available width
+        if target_cols > available_cols {
+            target_cols = available_cols;
+            // Recalculate rows based on width constraint
+            let constrained_width_px = target_cols as f64 * cell_width_px;
+            let constrained_height_px = constrained_width_px / video_aspect;
+            let constrained_rows = (constrained_height_px / cell_height_px).round() as u16;
+            return (target_cols, constrained_rows.min(available_rows));
+        }
+
+        (target_cols, target_rows)
     }
 
     // Convert a frame to the Kitty Graphics Protocol format
@@ -76,15 +124,31 @@ impl Encoder {
     }
 
     pub fn encode(&mut self) -> Res<()> {
-        let x_offset = (self.term_width as usize - self.width) / 2;
+        // Calculate display dimensions for Kitty scaling
+        let (display_cols, display_rows) = self.calculate_display_dimensions();
+        let (cell_width_px, cell_height_px) = self.cell_pixel_dimensions();
+
+        // Calculate the actual pixel size of the scaled video
+        let scaled_width_px = display_cols as f64 * cell_width_px;
+        let scaled_height_px = display_rows as f64 * cell_height_px;
+
+        // Calculate x offset to center horizontally
+        let available_width_px = self.term_cols as f64 * cell_width_px;
+        let x_offset = ((available_width_px - scaled_width_px) / 2.0).max(0.0) as usize;
+
+        // Calculate y offset: use force_y_offset if set, otherwise center within available space
         let y_offset = self.force_y_offset.unwrap_or_else(|| {
-            (self.term_height as usize - self.height) / 2
+            let available_rows = self.video_rows.unwrap_or(self.term_rows);
+            let available_height_px = available_rows as f64 * cell_height_px;
+            ((available_height_px - scaled_height_px) / 2.0).max(0.0) as usize
         });
 
         let encoded_control_data = self.encode_control_data(HashMap::from([
             ("f".into(), "24".into()),
             ("s".into(), format!("{}", self.width)),
             ("v".into(), format!("{}", self.height)),
+            ("c".into(), format!("{}", display_cols)),
+            ("r".into(), format!("{}", display_rows)),
             ("t".into(), "d".into()),
             ("a".into(), "T".into()),
             ("X".into(), format!("{}", x_offset)),
@@ -133,7 +197,7 @@ impl Encoder {
         encoded.as_bytes().to_vec()
     }
 
-    fn get_terminal_size() -> std::io::Result<(u16, u16)> {
+    fn get_terminal_size() -> std::io::Result<(u16, u16, u16, u16)> {
         let mut winsize: libc::winsize = unsafe { mem::zeroed() };
 
         let result = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut winsize) };
@@ -142,7 +206,7 @@ impl Encoder {
             return Err(std::io::Error::last_os_error());
         }
 
-        Ok((winsize.ws_xpixel, winsize.ws_ypixel))
+        Ok((winsize.ws_xpixel, winsize.ws_ypixel, winsize.ws_col, winsize.ws_row))
     }
 }
 
@@ -156,7 +220,7 @@ mod tests {
         let (_streaming_done_tx, producer_rx) = mpsc::channel();
         let (producer_tx, _encoding_done_rx) = mpsc::channel();
 
-        let encoder = Encoder::new(producer_rx, producer_tx, None).unwrap();
+        let encoder = Encoder::new(producer_rx, producer_tx, None, None).unwrap();
 
         assert_eq!(encoder.width, 640);
         assert_eq!(encoder.height, 360);
@@ -164,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_encode_control_data() {
-        let encoder = Encoder::new(mpsc::channel().1, mpsc::channel().0, None).unwrap();
+        let encoder = Encoder::new(mpsc::channel().1, mpsc::channel().0, None, None).unwrap();
 
         let control_data = HashMap::from([
             ("f".into(), "24".into()),
@@ -190,7 +254,7 @@ mod tests {
         let (_streaming_done_tx, producer_rx) = mpsc::channel();
         let (producer_tx, _encoding_done_rx) = mpsc::channel();
 
-        let encoder = Encoder::new(producer_rx, producer_tx, None).unwrap();
+        let encoder = Encoder::new(producer_rx, producer_tx, None, None).unwrap();
 
         assert!(
             encoder.term_width > 0 && encoder.term_height > 0,


### PR DESCRIPTION
### **User description**
## Summary
- Add Kitty protocol `c` (columns) and `r` (rows) parameters to scale video to fit the display area while maintaining aspect ratio
- In TUI mode, video scales to fill the 25-row video area
- In direct mode, video scales to fill the terminal

## Test plan
- [ ] Run `cargo build` and `cargo test` to verify compilation and tests pass
- [ ] Test in TUI mode: video should scale to fill the video area
- [ ] Test in direct mode (`cargo run -- --url <url>`): video should scale to fill terminal
- [ ] Test on high-resolution display to verify scaling works correctly


___

### **PR Type**
Enhancement


___

### **Description**
- Add Kitty protocol `c` (columns) and `r` (rows) parameters for video scaling

- Calculate display dimensions maintaining aspect ratio within available space

- Retrieve terminal cell dimensions to enable accurate pixel-to-cell conversion

- Pass `video_rows` constraint from TUI to encoder for area-aware scaling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TUI Mode"] -->|"video_rows constraint"| B["start_playback_async"]
  C["Direct Mode"] -->|"None"| B
  B -->|"video_rows param"| D["Encoder"]
  D -->|"calculate_display_dimensions"| E["Display Cols/Rows"]
  E -->|"c/r params"| F["Kitty Protocol"]
  D -->|"cell_pixel_dimensions"| G["Pixel Conversion"]
  G -->|"x/y offsets"| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Thread video_rows parameter through playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs

<ul><li>Updated <code>Encoder::new()</code> calls to pass <code>video_rows</code> parameter (None for <br>direct mode)<br> <li> Modified <code>start_playback_async()</code> signature to accept optional <br><code>video_rows</code> parameter<br> <li> Threaded <code>video_rows</code> constraint through playback initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/ThbltLmr/yt-term/pull/14/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Pass VIDEO_ROWS constraint to playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/mod.rs

<ul><li>Pass <code>Some(ui::VIDEO_ROWS)</code> when starting playback in results mode<br> <li> Updated comment to reflect video area constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/ThbltLmr/yt-term/pull/14/files#diff-fb8aef9cea1c223a4d74ddbc7d1b7acbb04ddb3a84227e2fdde704fff3f77edb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ui.rs</strong><dd><code>Export VIDEO_ROWS constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/ui.rs

<ul><li>Changed <code>VIDEO_ROWS</code> from private to public constant<br> <li> Enables external modules to access the 25-row video area constraint</ul>


</details>


  </td>
  <td><a href="https://github.com/ThbltLmr/yt-term/pull/14/files#diff-ea0931fe61d39e121985b80b27fba95e2e15c80517e40a9381b5132730c666da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>encoder.rs</strong><dd><code>Implement video scaling with Kitty protocol</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/video/encoder.rs

<ul><li>Added <code>term_cols</code> and <code>term_rows</code> fields to track terminal cell dimensions<br> <li> Added <code>video_rows</code> field to store optional area constraint<br> <li> Implemented <code>cell_pixel_dimensions()</code> to calculate pixel size per <br>terminal cell<br> <li> Implemented <code>calculate_display_dimensions()</code> to compute Kitty protocol <br>c/r parameters while maintaining aspect ratio<br> <li> Updated <code>encode()</code> to use calculated display dimensions and add c/r <br>parameters to Kitty control data<br> <li> Modified <code>get_terminal_size()</code> to return both pixel dimensions and cell <br>dimensions (4-tuple)<br> <li> Updated all <code>Encoder::new()</code> calls in tests to include <code>video_rows</code> <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/ThbltLmr/yt-term/pull/14/files#diff-f6fa330a42b6a093a89ff652320eb547c02840d72813bfc66b28e81cc85817a7">+73/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

